### PR TITLE
Sailpoint internal/pod aliases

### DIFF
--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -118,6 +118,8 @@ class KubernetesPodOperator(BaseOperator):
                 gen.add_mount(mount)
             for volume in self.volumes:
                 gen.add_volume(volume)
+            for host_aliases in self.hostaliases:
+                gen.host_aliases(host_aliases)
 
             pod = gen.make_pod(
                 namespace=self.namespace,
@@ -143,6 +145,7 @@ class KubernetesPodOperator(BaseOperator):
             pod.security_context = self.security_context
             pod.pod_runtime_info_envs = self.pod_runtime_info_envs
             pod.dnspolicy = self.dnspolicy
+            pod.host_aliases = self.host_aliases
 
             launcher = pod_launcher.PodLauncher(kube_client=client,
                                                 extract_xcom=self.do_xcom_push)
@@ -204,7 +207,8 @@ class KubernetesPodOperator(BaseOperator):
                  security_context=None,
                  pod_runtime_info_envs=None,
                  dnspolicy=None,
-                 *args,
+	             host_aliases=None,
+	             *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
         self.image = image
@@ -239,4 +243,5 @@ class KubernetesPodOperator(BaseOperator):
         self.configmaps = configmaps or []
         self.security_context = security_context or {}
         self.pod_runtime_info_envs = pod_runtime_info_envs or []
-        self.dnspolicy = dnspolicy
+        self.dnspolicy = dnspolicy,
+        self.host_aliases = host_aliases or []

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -118,8 +118,8 @@ class KubernetesPodOperator(BaseOperator):
                 gen.add_mount(mount)
             for volume in self.volumes:
                 gen.add_volume(volume)
-            for host_aliases in self.hostaliases:
-                gen.host_aliases(host_aliases)
+            for host_aliases in self.host_aliases:
+                gen.add_host_alias(host_aliases)
 
             pod = gen.make_pod(
                 namespace=self.namespace,

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -50,6 +50,7 @@ class KubernetesPodOperator(BaseOperator):
     :type volume_mounts: list[airflow.contrib.kubernetes.volume_mount.VolumeMount]
     :param volumes: volumes for launched pod. Includes ConfigMaps and PersistentVolumes
     :type volumes: list[airflow.contrib.kubernetes.volume.Volume]
+    :type host_aliases: list[airflow.contrib.kubernetes.hostalias.HostAlias]
     :param labels: labels to apply to the Pod
     :type labels: dict
     :param startup_timeout_seconds: timeout in seconds to startup the pod

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -208,8 +208,8 @@ class KubernetesPodOperator(BaseOperator):
                  security_context=None,
                  pod_runtime_info_envs=None,
                  dnspolicy=None,
-	             host_aliases=None,
-	             *args,
+                 host_aliases=None,
+                 *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
         self.image = image

--- a/airflow/kubernetes/hostalias.py
+++ b/airflow/kubernetes/hostalias.py
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+class HostAlias:
+	"""Defines Kubernetes Volume"""
+
+	def __init__(self, ip, hostnames):
+		self.ip = ip
+		self.hostnames = hostnames

--- a/airflow/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -258,4 +258,9 @@ class KubernetesRequestFactory(metaclass=ABCMeta):
     @staticmethod
     def extract_host_aliases(pod, req):
         if pod.host_aliases:
-            req['spec']['hostAliases'] = pod.host_aliases
+            req['spec']['hostAliases'] = []
+            for host_alias in pod.host_aliases:
+                req['spec']['hostAliases'].append({
+                    'ip': host_alias.ip,
+                    'hostnames': host_alias.hostnames
+                })

--- a/airflow/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -254,3 +254,8 @@ class KubernetesRequestFactory(metaclass=ABCMeta):
                     }
                 }
             )
+
+    @staticmethod
+    def extract_host_aliases(pod, req):
+        if pod.host_aliases:
+            req['spec']['hostAliases'] = pod.host_aliases

--- a/airflow/kubernetes/kubernetes_request_factory/pod_request_factory.py
+++ b/airflow/kubernetes/kubernetes_request_factory/pod_request_factory.py
@@ -68,6 +68,7 @@ spec:
         self.extract_tolerations(pod, req)
         self.extract_security_context(pod, req)
         self.extract_dnspolicy(pod, req)
+        self.extract_host_aliases(pod, req)
         return req
 
 
@@ -139,4 +140,5 @@ spec:
         self.extract_tolerations(pod, req)
         self.extract_security_context(pod, req)
         self.extract_dnspolicy(pod, req)
+        self.extract_host_aliases(pod, req)
         return req

--- a/airflow/kubernetes/pod.py
+++ b/airflow/kubernetes/pod.py
@@ -118,7 +118,8 @@ class Pod:
             security_context=None,
             configmaps=None,
             pod_runtime_info_envs=None,
-            dnspolicy=None
+            dnspolicy=None,
+            host_aliases=None
     ):
         self.image = image
         self.envs = envs or {}
@@ -145,4 +146,5 @@ class Pod:
         self.security_context = security_context
         self.configmaps = configmaps or []
         self.pod_runtime_info_envs = pod_runtime_info_envs or []
-        self.dnspolicy = dnspolicy
+        self.dnspolicy = dnspolicy,
+        self.host_aliases = host_aliases

--- a/airflow/kubernetes/pod.py
+++ b/airflow/kubernetes/pod.py
@@ -146,5 +146,5 @@ class Pod:
         self.security_context = security_context
         self.configmaps = configmaps or []
         self.pod_runtime_info_envs = pod_runtime_info_envs or []
-        self.dnspolicy = dnspolicy,
-        self.host_aliases = host_aliases
+        self.dnspolicy = dnspolicy
+        self.host_aliases = host_aliases or []

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -56,6 +56,7 @@ class PodLauncher(LoggingMixin):
         pod_mutation_hook(pod)
 
         req = self.kube_req_factory.create(pod)
+        print(req)
         self.log.debug('Pod Creation Request: \n%s', json.dumps(req, indent=2))
         try:
             resp = self._client.create_namespaced_pod(body=req, namespace=pod.namespace, **kwargs)

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -56,7 +56,6 @@ class PodLauncher(LoggingMixin):
         pod_mutation_hook(pod)
 
         req = self.kube_req_factory.create(pod)
-        print(req)
         self.log.debug('Pod Creation Request: \n%s', json.dumps(req, indent=2))
         try:
             resp = self._client.create_namespaced_pod(body=req, namespace=pod.namespace, **kwargs)

--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -307,6 +307,9 @@ class WorkerConfiguration(LoggingMixin):
 
         return volumes, volume_mounts
 
+    def _get_host_aliases(self):
+        return {}
+
     def generate_dag_volume_mount_path(self):
         if self.kube_config.dags_volume_claim or self.kube_config.dags_volume_host:
             dag_volume_mount_path = self.worker_airflow_dags
@@ -319,6 +322,7 @@ class WorkerConfiguration(LoggingMixin):
                  try_number, airflow_command, kube_executor_config):
         volumes_dict, volume_mounts_dict = self._get_volumes_and_mounts()
         worker_init_container_spec = self._get_init_containers()
+
         resources = Resources(
             request_memory=kube_executor_config.request_memory,
             request_cpu=kube_executor_config.request_cpu,
@@ -365,5 +369,6 @@ class WorkerConfiguration(LoggingMixin):
             affinity=affinity,
             tolerations=tolerations,
             security_context=self._get_security_context(),
-            configmaps=self._get_configmaps()
+            configmaps=self._get_configmaps(),
+            host_aliases=self._get_host_aliases()
         )

--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -307,9 +307,6 @@ class WorkerConfiguration(LoggingMixin):
 
         return volumes, volume_mounts
 
-    def _get_host_aliases(self):
-        return {}
-
     def generate_dag_volume_mount_path(self):
         if self.kube_config.dags_volume_claim or self.kube_config.dags_volume_host:
             dag_volume_mount_path = self.worker_airflow_dags
@@ -322,7 +319,6 @@ class WorkerConfiguration(LoggingMixin):
                  try_number, airflow_command, kube_executor_config):
         volumes_dict, volume_mounts_dict = self._get_volumes_and_mounts()
         worker_init_container_spec = self._get_init_containers()
-
         resources = Resources(
             request_memory=kube_executor_config.request_memory,
             request_cpu=kube_executor_config.request_cpu,

--- a/tests/minikube/test_kubernetes_pod_operator.py
+++ b/tests/minikube/test_kubernetes_pod_operator.py
@@ -317,19 +317,18 @@ class KubernetesPodOperatorTest(unittest.TestCase):
     @staticmethod
     def test_host_aliases():
         with mock.patch.object(PodLauncher, 'log') as mock_logger:
-
             host_alias = HostAlias(ip='1.2.3.4', hostnames=['test1', 'test2'])
             host_alias2 = HostAlias(ip='5.6.7.8', hostnames=['test3', 'test4'])
 
         k = KubernetesPodOperator(
-                namespace='default',
-                image="ubuntu:16.04",
-                cmds=["bash", "-cx"],
-                arguments=["cat /root/mount_file/test.txt"],
-                labels={"foo": "bar"},
-                host_aliases=[host_alias, host_alias2],
-                name="test",
-                task_id="task"
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["cat /root/mount_file/test.txt"],
+            labels={"foo": "bar"},
+            host_aliases=[host_alias, host_alias2],
+            name="test",
+            task_id="task"
         )
         k.execute(None)
         mock_logger.info.assert_any_call(b"retrieved from mount\n")

--- a/tests/minikube/test_kubernetes_pod_operator.py
+++ b/tests/minikube/test_kubernetes_pod_operator.py
@@ -19,6 +19,7 @@ import unittest
 import os
 import shutil
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.kubernetes.hostalias import HostAlias
 from airflow.kubernetes.secret import Secret
 from airflow import AirflowException
 from kubernetes.client.rest import ApiException
@@ -312,6 +313,26 @@ class KubernetesPodOperatorTest(unittest.TestCase):
             )
             k.execute(None)
             mock_logger.info.assert_any_call(b"retrieved from mount\n")
+
+    @staticmethod
+    def test_host_aliases():
+        with mock.patch.object(PodLauncher, 'log') as mock_logger:
+
+            host_alias = HostAlias(ip='1.2.3.4', hostnames=['test1', 'test2'])
+            host_alias2 = HostAlias(ip='5.6.7.8', hostnames=['test3', 'test4'])
+
+        k = KubernetesPodOperator(
+                namespace='default',
+                image="ubuntu:16.04",
+                cmds=["bash", "-cx"],
+                arguments=["cat /root/mount_file/test.txt"],
+                labels={"foo": "bar"},
+                host_aliases=[host_alias, host_alias2],
+                name="test",
+                task_id="task"
+        )
+        k.execute(None)
+        mock_logger.info.assert_any_call(b"retrieved from mount\n")
 
     @staticmethod
     def test_run_as_user_root():


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
